### PR TITLE
[1.2.1] Enable strings for version param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2021-09-29
+
+### Added
+
+- New tests for SSR behavior
+- New tests for versioning
+- The `version` can now be a string in addition to a number
+  - This is especially useful if you want to hash a data set to invalidate the cache dynamically
+
+### Changed
+
+- Dependency updates
+
 ## [1.2.0] - 2021-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ _See notes on SSR compatibility for the server-side behavior of the default valu
 
 ## Versioning and Cache Busting
 
-You can pass an optional number to the hook to apply a specific version to your stored data. If the structure of your data changes, users who have stored data from the previous structure can experience issues when the incompatible data is applied to the new structure. Think of the `version` param as a schema version for the data.
+You can pass an optional number or string to the hook to apply a specific version to your stored data. If the structure of your data changes, users who have stored data from the previous structure can experience issues when the incompatible data is applied to the new structure. Think of the `version` param as a schema version for the data.
 
 ```jsx
 const schemaVersion = 2;
@@ -109,7 +109,9 @@ function MyComponent() {
 }
 ```
 
-There is no enforcement of standards on the version number—Haversack will do a simple `===` equality check to determine if the version number has changed. Any change in version number, forward or backward, will cause the stored data to be deleted to await new data with the current version number. If previous data was stored without a version number, the data will be invalidated when a version number is introduced.
+There is no enforcement of standards on the version—Haversack will do a simple `===` equality check to determine if the version has changed. Any change in version number, forward or backward, will cause the stored data to be deleted to await new data with the current version number. If previous data was stored without a version number, the data will be invalidated when a version number is introduced.
+
+Using a string for the version is especially useful if you want to create a hash of a data set to dynamically determine whether or not to invalidate the cache.
 
 ## Reset the Stored Value
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,23 @@
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react-hooks": "7.0.2",
-        "@types/jest": "27.0.1",
-        "@types/react": "17.0.19",
-        "@typescript-eslint/eslint-plugin": "4.30.0",
-        "@typescript-eslint/parser": "4.30.0",
+        "@types/jest": "27.0.2",
+        "@types/react": "17.0.24",
+        "@typescript-eslint/eslint-plugin": "4.32.0",
+        "@typescript-eslint/parser": "4.32.0",
         "eslint": "7.32.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-react-hooks": "4.2.0",
         "husky": "7.0.2",
-        "jest": "27.1.0",
-        "jest-localstorage-mock": "2.4.17",
+        "jest": "27.2.4",
+        "jest-localstorage-mock": "2.4.18",
         "lint-staged": "11.1.2",
         "mockdate": "3.0.5",
-        "prettier": "2.3.2",
+        "prettier": "2.4.1",
         "react-test-renderer": "17.0.2",
         "ts-jest": "27.0.5",
-        "typescript": "4.4.2"
+        "typescript": "4.4.3"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17"
@@ -764,16 +764,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
-      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.4.tgz",
+      "integrity": "sha512-94znCKynPZpDpYHQ6esRJSc11AmONrVkBOBZiD7S+bSubHhrUfbS95EY5HIOxhm4PQO7cnvZkL3oJcY0oMA+Wg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-message-util": "^27.2.4",
+        "jest-util": "^27.2.4",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -781,37 +781,36 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
-      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.4.tgz",
+      "integrity": "sha512-UNQLyy+rXoojNm2MGlapgzWhZD1CT1zcHZQYeiD0xE7MtJfC19Q6J5D/Lm2l7i4V97T30usKDoEtjI8vKwWcLg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.1.0",
-        "@jest/reporters": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/reporters": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.1.0",
-        "jest-config": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-changed-files": "^27.2.4",
+        "jest-config": "^27.2.4",
+        "jest-haste-map": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-resolve-dependencies": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
-        "jest-watcher": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-resolve-dependencies": "^27.2.4",
+        "jest-runner": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
+        "jest-watcher": "^27.2.4",
         "micromatch": "^4.0.4",
-        "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
@@ -829,62 +828,62 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
-      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.4.tgz",
+      "integrity": "sha512-wkuui5yr3SSQW0XD0Qm3TATUbL/WE3LDEM3ulC+RCQhMf2yxhci8x7svGkZ4ivJ6Pc94oOzpZ6cdHBAMSYd1ew==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0"
+        "jest-mock": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
-      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.4.tgz",
+      "integrity": "sha512-cs/TzvwWUM7kAA6Qm/890SK6JJ2pD5RfDNM3SSEom6BmdyV6OiWP1qf/pqo6ts6xwpcM36oN0wSEzcZWc6/B6w==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
-        "@sinonjs/fake-timers": "^7.0.2",
+        "@jest/types": "^27.2.4",
+        "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-message-util": "^27.2.4",
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
-      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.4.tgz",
+      "integrity": "sha512-DRsRs5dh0i+fA9mGHylTU19+8fhzNJoEzrgsu+zgJoZth3x8/0juCQ8nVVdW1er4Cqifb/ET7/hACYVPD0dBEA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "expect": "^27.1.0"
+        "@jest/environment": "^27.2.4",
+        "@jest/types": "^27.2.4",
+        "expect": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
-      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.4.tgz",
+      "integrity": "sha512-LHeSdDnDZkDnJ8kvnjcqV8P1Yv/32yL4d4XfR5gBiy3xGO0onwll1QEbvtW96fIwhx2nejug0GTaEdNDoyr3fQ==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -895,15 +894,15 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.0.0"
+        "v8-to-istanbul": "^8.1.0"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -932,13 +931,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
-      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.4.tgz",
+      "integrity": "sha512-eU+PRo0+lIS01b0dTmMdVZ0TtcRSxEaYquZTRFMQz6CvsehGhx9bRzi9Zdw6VROviJyv7rstU+qAMX5pNBmnfQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -947,36 +946,36 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
-      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.4.tgz",
+      "integrity": "sha512-fpk5eknU3/DXE2QCCG1wv/a468+cfPo3Asu6d6yUtM9LOPh709ubZqrhuUOYfM8hXMrIpIdrv1CdCrWWabX0rQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-runtime": "^27.1.0"
+        "jest-haste-map": "^27.2.4",
+        "jest-runtime": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
-      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.4.tgz",
+      "integrity": "sha512-n5FlX2TH0oQGwyVDKPxdJ5nI2sO7TJBFe3u3KaAtt7TOiV4yL+Y+rSFDl+Ic5MpbiA/eqXmLAQxjnBmWgS2rEA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.4",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -988,9 +987,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-      "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1048,9 +1047,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
+      "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
@@ -1095,9 +1094,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.1.15",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+      "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1169,9 +1168,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^27.0.0",
@@ -1197,9 +1196,9 @@
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -1209,9 +1208,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
+      "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1265,15 +1264,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
-      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz",
+      "integrity": "sha512-+OWTuWRSbWI1KDK8iEyG/6uK2rTm3kpS38wuVifGUTDB6kjEuNrzBI1MUtxnkneuWG/23QehABe2zHHrj+4yuA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.30.0",
-        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/experimental-utils": "4.32.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
@@ -1295,16 +1295,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
-      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz",
+      "integrity": "sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1320,14 +1329,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
-      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.32.0.tgz",
+      "integrity": "sha512-lhtYqQ2iEPV5JqV7K+uOVlPePjClj4dOw7K4/Z1F2yvjIUvyr13yJnDzkK6uon4BjHYuHy3EG0c2Z9jEhFk56w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1347,13 +1356,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz",
+      "integrity": "sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0"
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1364,9 +1373,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz",
+      "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1377,13 +1386,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz",
+      "integrity": "sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1404,12 +1413,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
+      "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/types": "4.32.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1544,9 +1553,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1614,16 +1623,16 @@
       "dev": true
     },
     "node_modules/babel-jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
-      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
+      "integrity": "sha512-f24OmxyWymk5jfgLdlCMu4fTs4ldxFBIdn5sJdhvGC1m08rSkJ5hYbWkNmfBSvE/DjhCVNSHXepxsI6THGfGsg==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.6",
+        "babel-preset-jest": "^27.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -1652,9 +1661,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
-      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz",
+      "integrity": "sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -1690,12 +1699,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
-      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz",
+      "integrity": "sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-plugin-jest-hoist": "^27.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -2611,16 +2620,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
-      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.4.tgz",
+      "integrity": "sha512-gOtuonQ8TCnbNNCSw2fhVzRf8EFYDII4nB5NmG4IEV0rbUnW1I5zXvoTntU4iicB/Uh0oZr20NGlOLdJiwsOZA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6"
       },
       "engines": {
@@ -2680,9 +2689,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3122,9 +3131,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3316,14 +3325,14 @@
       }
     },
     "node_modules/jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
-      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.4.tgz",
+      "integrity": "sha512-h4uqb1EQLfPulWyUFFWv9e9Nn8sCqsJ/j3wk/KCY0p4s4s0ICCfP3iMf6hRf5hEhsDyvyrCgKiZXma63gMz16A==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.1.0",
+        "@jest/core": "^27.2.4",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.1.0"
+        "jest-cli": "^27.2.4"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3341,12 +3350,12 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
-      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.2.4.tgz",
+      "integrity": "sha512-eeO1C1u4ex7pdTroYXezr+rbr957myyVoKGjcY4R1TJi3A+9v+4fu1Iv9J4eLq1bgFyT3O3iRWU9lZsEE7J72Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       },
@@ -3355,27 +3364,27 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
-      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.4.tgz",
+      "integrity": "sha512-TtheheTElrGjlsY9VxkzUU1qwIx05ItIusMVKnvNkMt4o/PeegLRcjq3Db2Jz0GGdBalJdbzLZBgeulZAJxJWA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
@@ -3385,23 +3394,23 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
-      "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.4.tgz",
+      "integrity": "sha512-4kpQQkg74HYLaXo3nzwtg4PYxSLgL7puz1LXHj5Tu85KmlIpxQFjRkXlx4V47CYFFIDoyl3rHA/cXOxUWyMpNg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/core": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-config": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "prompts": "^2.0.1",
-        "yargs": "^16.0.3"
+        "yargs": "^16.2.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3419,32 +3428,32 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
-      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.4.tgz",
+      "integrity": "sha512-tWy0UxhdzqiKyp4l5Vq4HxLyD+gH5td+GCF3c22/DJ0bYAOsMo+qi2XtbJI6oYMH5JOJQs9nLW/r34nvFCehjA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "babel-jest": "^27.1.0",
+        "@jest/test-sequencer": "^27.2.4",
+        "@jest/types": "^27.2.4",
+        "babel-jest": "^27.2.4",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.1.0",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
+        "jest-circus": "^27.2.4",
+        "jest-environment-jsdom": "^27.2.4",
+        "jest-environment-node": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.1.0",
+        "jest-jasmine2": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-runner": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3459,15 +3468,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-      "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.4.tgz",
+      "integrity": "sha512-bLAVlDSCR3gqUPGv+4nzVpEXGsHh98HjUL7Vb2hVyyuBDoQmja8eJb0imUABsuxBeUVmf47taJSAd9nDrwWKEg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3486,33 +3495,33 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
-      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.4.tgz",
+      "integrity": "sha512-w9XVc+0EDBUTJS4xBNJ7N2JCcWItFd006lFjz77OarAQcQ10eFDBMrfDv2GBJMKlXe9aq0HrIIF51AXcZrRJyg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0"
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
-      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.4.tgz",
+      "integrity": "sha512-X70pTXFSypD7AIzKT1mLnDi5hP9w9mdTRcOGOmoDoBrNyNEg4rYm6d4LQWFLc9ps1VnMuDOkFSG0wjSNYGjkng==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4",
         "jsdom": "^16.6.0"
       },
       "engines": {
@@ -3520,17 +3529,17 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
-      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.4.tgz",
+      "integrity": "sha512-ZbVbFSnbzTvhLOIkqh5lcLuGCCFvtG4xTXIRPK99rV2KzQT3kNg16KZwfTnLNlIiWCE8do960eToeDfcqmpSAw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3546,12 +3555,12 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
-      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.4.tgz",
+      "integrity": "sha512-bkJ4bT00T2K+1NZXbRcyKnbJ42I6QBvoDNMTAQQDBhaGNnZreiQKUNqax0e6hLTx7E75pKDeltVu3V1HAdu+YA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -3559,8 +3568,8 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       },
@@ -3572,28 +3581,28 @@
       }
     },
     "node_modules/jest-jasmine2": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
-      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.4.tgz",
+      "integrity": "sha512-fcffjO/xLWLVnW2ct3No4EksxM5RyPwHDYu9QU+90cC+/eSMLkFAxS55vkqsxexOO5zSsZ3foVpMQcg/amSeIQ==",
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.1.0",
+        "@jest/environment": "^27.2.4",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4",
         "throat": "^6.0.1"
       },
       "engines": {
@@ -3601,55 +3610,55 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
-      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.4.tgz",
+      "integrity": "sha512-SrcHWbe0EHg/bw2uBjVoHacTo5xosl068x2Q0aWsjr2yYuW2XwqrSkZV4lurUop0jhv1709ymG4or+8E4sH27Q==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-localstorage-mock": {
-      "version": "2.4.17",
-      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.17.tgz",
-      "integrity": "sha512-Rs1i1Dbz2j8lRgpRuTAXCp8jHjYn1dgmldBCQy08yLu3K+Ujz9em9WEu9ZZlM0WYsoUlJZDU1jUXL+dVsSWfLg==",
+      "version": "2.4.18",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.18.tgz",
+      "integrity": "sha512-zQTrtPeyGXvqM9Vw8nYd39Z0YAD2SK2hptyxLLaR/Ci5X72pcPBaiTDTfTeNq8FOuH/aVUSp8jhJUeFHMhuNeg==",
       "dev": true,
       "engines": {
         "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
-      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.4.tgz",
+      "integrity": "sha512-nQeLfFAIPPkyhkDfifAPfP/U5wm1x0fLtAzqXZSSKckXDNuk2aaOfQiDYv1Mgf5GY6yOsxfUnvNm3dDjXM+BXw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
-      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.4.tgz",
+      "integrity": "sha512-wbKT/BNGnBVB9nzi+IoaLkXt6fbSvqUxx+IYY66YFh96J3goY33BAaNG3uPqaw/Sh/FR9YpXGVDfd5DJdbh4nA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -3670,12 +3679,12 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
-      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.2.4.tgz",
+      "integrity": "sha512-iVRU905rutaAoUcrt5Tm1JoHHWi24YabqEGXjPJI4tAyA6wZ7mzDi3GrZ+M7ebgWBqUkZE93GAx1STk7yCMIQA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*"
       },
       "engines": {
@@ -3709,19 +3718,19 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
-      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.4.tgz",
+      "integrity": "sha512-IsAO/3+3BZnKjI2I4f3835TBK/90dxR7Otgufn3mnrDFTByOSXclDi3G2XJsawGV4/18IMLARJ+V7Wm7t+J89Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       },
@@ -3730,45 +3739,45 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
-      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.4.tgz",
+      "integrity": "sha512-i5s7Uh9B3Q6uwxLpMhNKlgBf6pcemvWaORxsW1zNF/YCY3jd5EftvnGBI+fxVwJ1CBxkVfxqCvm1lpZkbaoGmg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.1.0"
+        "jest-snapshot": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
-      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.4.tgz",
+      "integrity": "sha512-hIo5PPuNUyVDidZS8EetntuuJbQ+4IHWxmHgYZz9FIDbG2wcZjrP6b52uMDjAEQiHAn8yn8ynNe+TL8UuGFYKg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/environment": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-leak-detector": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-environment-jsdom": "^27.2.4",
+        "jest-environment-node": "^27.2.4",
+        "jest-haste-map": "^27.2.4",
+        "jest-leak-detector": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       },
@@ -3777,19 +3786,19 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
-      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.4.tgz",
+      "integrity": "sha512-ICKzzYdjIi70P17MZsLLIgIQFCQmIjMFf+xYww3aUySiUA/QBPUTdUqo5B2eg4HOn9/KkUsV0z6GVgaqAPBJvg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/globals": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/globals": "^27.2.4",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -3798,17 +3807,17 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-mock": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^16.0.3"
+        "yargs": "^16.2.0"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3828,9 +3837,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
-      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.4.tgz",
+      "integrity": "sha512-5DFxK31rYS8X8C6WXsFx8XxrxW3PGa6+9IrUcZdTLg1aEyXDGIeiBh4jbwvh655bg/9vTETbEj/njfZicHTZZw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.7.2",
@@ -3839,23 +3848,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-util": "^27.2.4",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.4",
         "semver": "^7.3.2"
       },
       "engines": {
@@ -3863,12 +3872,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
-      "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.4.tgz",
+      "integrity": "sha512-mW++4u+fSvAt3YBWm5IpbmRAceUqa2B++JlUZTiuEt2AmNYn0Yw5oay4cP17TGsMINRNPSGiJ2zNnX60g+VbFg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -3880,17 +3889,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
-      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.4.tgz",
+      "integrity": "sha512-VMtbxbkd7LHnIH7PChdDtrluCFRJ4b1YV2YJzNwwsASMWftq/HgqiqjvptBOWyWOtevgO3f14wPxkPcLlVBRog==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -3909,17 +3918,17 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
-      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.4.tgz",
+      "integrity": "sha512-LXC/0+dKxhK7cfF7reflRYlzDIaQE+fL4ynhKhzg8IMILNMuI4xcjXXfUJady7OR4/TZeMg7X8eHx8uan9vqaQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.4",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -3927,9 +3936,9 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.4.tgz",
+      "integrity": "sha512-Zq9A2Pw59KkVjBBKD1i3iE2e22oSjXhUKKuAK1HGX8flGwkm6NMozyEYzKd41hXc64dbd/0eWFeEEuxqXyhM+g==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4020,9 +4029,9 @@
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -4516,18 +4525,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -4712,9 +4709,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -4736,13 +4733,13 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-      "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.0",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -5155,9 +5152,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -5171,9 +5168,9 @@
       "dev": true
     },
     "node_modules/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -5419,9 +5416,9 @@
       "dev": true
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -5575,9 +5572,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5612,9 +5609,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5762,9 +5759,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -6413,104 +6410,103 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
-      "integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.2.4.tgz",
+      "integrity": "sha512-94znCKynPZpDpYHQ6esRJSc11AmONrVkBOBZiD7S+bSubHhrUfbS95EY5HIOxhm4PQO7cnvZkL3oJcY0oMA+Wg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-message-util": "^27.2.4",
+        "jest-util": "^27.2.4",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
-      "integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.2.4.tgz",
+      "integrity": "sha512-UNQLyy+rXoojNm2MGlapgzWhZD1CT1zcHZQYeiD0xE7MtJfC19Q6J5D/Lm2l7i4V97T30usKDoEtjI8vKwWcLg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/reporters": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/reporters": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.1.0",
-        "jest-config": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-changed-files": "^27.2.4",
+        "jest-config": "^27.2.4",
+        "jest-haste-map": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-resolve-dependencies": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
-        "jest-watcher": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-resolve-dependencies": "^27.2.4",
+        "jest-runner": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
+        "jest-watcher": "^27.2.4",
         "micromatch": "^4.0.4",
-        "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
     },
     "@jest/environment": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
-      "integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.2.4.tgz",
+      "integrity": "sha512-wkuui5yr3SSQW0XD0Qm3TATUbL/WE3LDEM3ulC+RCQhMf2yxhci8x7svGkZ4ivJ6Pc94oOzpZ6cdHBAMSYd1ew==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0"
+        "jest-mock": "^27.2.4"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
-      "integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.2.4.tgz",
+      "integrity": "sha512-cs/TzvwWUM7kAA6Qm/890SK6JJ2pD5RfDNM3SSEom6BmdyV6OiWP1qf/pqo6ts6xwpcM36oN0wSEzcZWc6/B6w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
-        "@sinonjs/fake-timers": "^7.0.2",
+        "@jest/types": "^27.2.4",
+        "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-message-util": "^27.2.4",
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4"
       }
     },
     "@jest/globals": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
-      "integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.2.4.tgz",
+      "integrity": "sha512-DRsRs5dh0i+fA9mGHylTU19+8fhzNJoEzrgsu+zgJoZth3x8/0juCQ8nVVdW1er4Cqifb/ET7/hACYVPD0dBEA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "expect": "^27.1.0"
+        "@jest/environment": "^27.2.4",
+        "@jest/types": "^27.2.4",
+        "expect": "^27.2.4"
       }
     },
     "@jest/reporters": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
-      "integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.2.4.tgz",
+      "integrity": "sha512-LHeSdDnDZkDnJ8kvnjcqV8P1Yv/32yL4d4XfR5gBiy3xGO0onwll1QEbvtW96fIwhx2nejug0GTaEdNDoyr3fQ==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -6521,15 +6517,15 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^8.0.0"
+        "v8-to-istanbul": "^8.1.0"
       }
     },
     "@jest/source-map": {
@@ -6544,45 +6540,45 @@
       }
     },
     "@jest/test-result": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
-      "integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.2.4.tgz",
+      "integrity": "sha512-eU+PRo0+lIS01b0dTmMdVZ0TtcRSxEaYquZTRFMQz6CvsehGhx9bRzi9Zdw6VROviJyv7rstU+qAMX5pNBmnfQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
-      "integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.2.4.tgz",
+      "integrity": "sha512-fpk5eknU3/DXE2QCCG1wv/a468+cfPo3Asu6d6yUtM9LOPh709ubZqrhuUOYfM8hXMrIpIdrv1CdCrWWabX0rQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-runtime": "^27.1.0"
+        "jest-haste-map": "^27.2.4",
+        "jest-runtime": "^27.2.4"
       }
     },
     "@jest/transform": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
-      "integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.2.4.tgz",
+      "integrity": "sha512-n5FlX2TH0oQGwyVDKPxdJ5nI2sO7TJBFe3u3KaAtt7TOiV4yL+Y+rSFDl+Ic5MpbiA/eqXmLAQxjnBmWgS2rEA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.4",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -6591,9 +6587,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-      "integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6639,9 +6635,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
+      "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -6667,9 +6663,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.15",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-      "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+      "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -6741,9 +6737,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -6769,9 +6765,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
     },
     "@types/prop-types": {
@@ -6781,9 +6777,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.24.tgz",
+      "integrity": "sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -6837,70 +6833,79 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
-      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.32.0.tgz",
+      "integrity": "sha512-+OWTuWRSbWI1KDK8iEyG/6uK2rTm3kpS38wuVifGUTDB6kjEuNrzBI1MUtxnkneuWG/23QehABe2zHHrj+4yuA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.30.0",
-        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/experimental-utils": "4.32.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
-      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz",
+      "integrity": "sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
-      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.32.0.tgz",
+      "integrity": "sha512-lhtYqQ2iEPV5JqV7K+uOVlPePjClj4dOw7K4/Z1F2yvjIUvyr13yJnDzkK6uon4BjHYuHy3EG0c2Z9jEhFk56w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.32.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/typescript-estree": "4.32.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz",
+      "integrity": "sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0"
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz",
+      "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz",
+      "integrity": "sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/visitor-keys": "4.30.0",
+        "@typescript-eslint/types": "4.32.0",
+        "@typescript-eslint/visitor-keys": "4.32.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -6909,12 +6914,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
+      "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/types": "4.32.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -7008,9 +7013,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -7060,16 +7065,16 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
-      "integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
+      "integrity": "sha512-f24OmxyWymk5jfgLdlCMu4fTs4ldxFBIdn5sJdhvGC1m08rSkJ5hYbWkNmfBSvE/DjhCVNSHXepxsI6THGfGsg==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.0.6",
+        "babel-preset-jest": "^27.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -7089,9 +7094,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
-      "integrity": "sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz",
+      "integrity": "sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -7121,12 +7126,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
-      "integrity": "sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz",
+      "integrity": "sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-plugin-jest-hoist": "^27.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -7811,16 +7816,16 @@
       "dev": true
     },
     "expect": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
-      "integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.4.tgz",
+      "integrity": "sha512-gOtuonQ8TCnbNNCSw2fhVzRf8EFYDII4nB5NmG4IEV0rbUnW1I5zXvoTntU4iicB/Uh0oZr20NGlOLdJiwsOZA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
@@ -7870,9 +7875,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -8199,9 +8204,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -8341,113 +8346,113 @@
       }
     },
     "jest": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
-      "integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.2.4.tgz",
+      "integrity": "sha512-h4uqb1EQLfPulWyUFFWv9e9Nn8sCqsJ/j3wk/KCY0p4s4s0ICCfP3iMf6hRf5hEhsDyvyrCgKiZXma63gMz16A==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.1.0",
+        "@jest/core": "^27.2.4",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.1.0"
+        "jest-cli": "^27.2.4"
       }
     },
     "jest-changed-files": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
-      "integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.2.4.tgz",
+      "integrity": "sha512-eeO1C1u4ex7pdTroYXezr+rbr957myyVoKGjcY4R1TJi3A+9v+4fu1Iv9J4eLq1bgFyT3O3iRWU9lZsEE7J72Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       }
     },
     "jest-circus": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
-      "integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.2.4.tgz",
+      "integrity": "sha512-TtheheTElrGjlsY9VxkzUU1qwIx05ItIusMVKnvNkMt4o/PeegLRcjq3Db2Jz0GGdBalJdbzLZBgeulZAJxJWA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       }
     },
     "jest-cli": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
-      "integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.2.4.tgz",
+      "integrity": "sha512-4kpQQkg74HYLaXo3nzwtg4PYxSLgL7puz1LXHj5Tu85KmlIpxQFjRkXlx4V47CYFFIDoyl3rHA/cXOxUWyMpNg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/core": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "import-local": "^3.0.2",
-        "jest-config": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-config": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "prompts": "^2.0.1",
-        "yargs": "^16.0.3"
+        "yargs": "^16.2.0"
       }
     },
     "jest-config": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
-      "integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.2.4.tgz",
+      "integrity": "sha512-tWy0UxhdzqiKyp4l5Vq4HxLyD+gH5td+GCF3c22/DJ0bYAOsMo+qi2XtbJI6oYMH5JOJQs9nLW/r34nvFCehjA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.1.0",
-        "@jest/types": "^27.1.0",
-        "babel-jest": "^27.1.0",
+        "@jest/test-sequencer": "^27.2.4",
+        "@jest/types": "^27.2.4",
+        "babel-jest": "^27.2.4",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
         "is-ci": "^3.0.0",
-        "jest-circus": "^27.1.0",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
+        "jest-circus": "^27.2.4",
+        "jest-environment-jsdom": "^27.2.4",
+        "jest-environment-node": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "jest-jasmine2": "^27.1.0",
+        "jest-jasmine2": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-runner": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-runner": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-diff": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-      "integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.4.tgz",
+      "integrity": "sha512-bLAVlDSCR3gqUPGv+4nzVpEXGsHh98HjUL7Vb2hVyyuBDoQmja8eJb0imUABsuxBeUVmf47taJSAd9nDrwWKEg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-docblock": {
@@ -8460,45 +8465,45 @@
       }
     },
     "jest-each": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
-      "integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.2.4.tgz",
+      "integrity": "sha512-w9XVc+0EDBUTJS4xBNJ7N2JCcWItFd006lFjz77OarAQcQ10eFDBMrfDv2GBJMKlXe9aq0HrIIF51AXcZrRJyg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0"
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
-      "integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.2.4.tgz",
+      "integrity": "sha512-X70pTXFSypD7AIzKT1mLnDi5hP9w9mdTRcOGOmoDoBrNyNEg4rYm6d4LQWFLc9ps1VnMuDOkFSG0wjSNYGjkng==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
-      "integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.2.4.tgz",
+      "integrity": "sha512-ZbVbFSnbzTvhLOIkqh5lcLuGCCFvtG4xTXIRPK99rV2KzQT3kNg16KZwfTnLNlIiWCE8do960eToeDfcqmpSAw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
-        "jest-mock": "^27.1.0",
-        "jest-util": "^27.1.0"
+        "jest-mock": "^27.2.4",
+        "jest-util": "^27.2.4"
       }
     },
     "jest-get-type": {
@@ -8508,12 +8513,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
-      "integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.2.4.tgz",
+      "integrity": "sha512-bkJ4bT00T2K+1NZXbRcyKnbJ42I6QBvoDNMTAQQDBhaGNnZreiQKUNqax0e6hLTx7E75pKDeltVu3V1HAdu+YA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -8522,79 +8527,79 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
-      "integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.2.4.tgz",
+      "integrity": "sha512-fcffjO/xLWLVnW2ct3No4EksxM5RyPwHDYu9QU+90cC+/eSMLkFAxS55vkqsxexOO5zSsZ3foVpMQcg/amSeIQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.1.0",
+        "@jest/environment": "^27.2.4",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "pretty-format": "^27.1.0",
+        "jest-each": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "pretty-format": "^27.2.4",
         "throat": "^6.0.1"
       }
     },
     "jest-leak-detector": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
-      "integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.2.4.tgz",
+      "integrity": "sha512-SrcHWbe0EHg/bw2uBjVoHacTo5xosl068x2Q0aWsjr2yYuW2XwqrSkZV4lurUop0jhv1709ymG4or+8E4sH27Q==",
       "dev": true,
       "requires": {
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-localstorage-mock": {
-      "version": "2.4.17",
-      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.17.tgz",
-      "integrity": "sha512-Rs1i1Dbz2j8lRgpRuTAXCp8jHjYn1dgmldBCQy08yLu3K+Ujz9em9WEu9ZZlM0WYsoUlJZDU1jUXL+dVsSWfLg==",
+      "version": "2.4.18",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.18.tgz",
+      "integrity": "sha512-zQTrtPeyGXvqM9Vw8nYd39Z0YAD2SK2hptyxLLaR/Ci5X72pcPBaiTDTfTeNq8FOuH/aVUSp8jhJUeFHMhuNeg==",
       "dev": true
     },
     "jest-matcher-utils": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
-      "integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.4.tgz",
+      "integrity": "sha512-nQeLfFAIPPkyhkDfifAPfP/U5wm1x0fLtAzqXZSSKckXDNuk2aaOfQiDYv1Mgf5GY6yOsxfUnvNm3dDjXM+BXw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-message-util": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
-      "integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.4.tgz",
+      "integrity": "sha512-wbKT/BNGnBVB9nzi+IoaLkXt6fbSvqUxx+IYY66YFh96J3goY33BAaNG3uPqaw/Sh/FR9YpXGVDfd5DJdbh4nA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -8611,12 +8616,12 @@
       }
     },
     "jest-mock": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
-      "integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.2.4.tgz",
+      "integrity": "sha512-iVRU905rutaAoUcrt5Tm1JoHHWi24YabqEGXjPJI4tAyA6wZ7mzDi3GrZ+M7ebgWBqUkZE93GAx1STk7yCMIQA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*"
       }
     },
@@ -8634,78 +8639,78 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
-      "integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.2.4.tgz",
+      "integrity": "sha512-IsAO/3+3BZnKjI2I4f3835TBK/90dxR7Otgufn3mnrDFTByOSXclDi3G2XJsawGV4/18IMLARJ+V7Wm7t+J89Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "chalk": "^4.0.0",
         "escalade": "^3.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "resolve": "^1.20.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
-      "integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.4.tgz",
+      "integrity": "sha512-i5s7Uh9B3Q6uwxLpMhNKlgBf6pcemvWaORxsW1zNF/YCY3jd5EftvnGBI+fxVwJ1CBxkVfxqCvm1lpZkbaoGmg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-snapshot": "^27.1.0"
+        "jest-snapshot": "^27.2.4"
       }
     },
     "jest-runner": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
-      "integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.2.4.tgz",
+      "integrity": "sha512-hIo5PPuNUyVDidZS8EetntuuJbQ+4IHWxmHgYZz9FIDbG2wcZjrP6b52uMDjAEQiHAn8yn8ynNe+TL8UuGFYKg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/environment": "^27.2.4",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-docblock": "^27.0.6",
-        "jest-environment-jsdom": "^27.1.0",
-        "jest-environment-node": "^27.1.0",
-        "jest-haste-map": "^27.1.0",
-        "jest-leak-detector": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-runtime": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-worker": "^27.1.0",
+        "jest-environment-jsdom": "^27.2.4",
+        "jest-environment-node": "^27.2.4",
+        "jest-haste-map": "^27.2.4",
+        "jest-leak-detector": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-runtime": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-worker": "^27.2.4",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       }
     },
     "jest-runtime": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
-      "integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.2.4.tgz",
+      "integrity": "sha512-ICKzzYdjIi70P17MZsLLIgIQFCQmIjMFf+xYww3aUySiUA/QBPUTdUqo5B2eg4HOn9/KkUsV0z6GVgaqAPBJvg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.1.0",
-        "@jest/environment": "^27.1.0",
-        "@jest/fake-timers": "^27.1.0",
-        "@jest/globals": "^27.1.0",
+        "@jest/console": "^27.2.4",
+        "@jest/environment": "^27.2.4",
+        "@jest/fake-timers": "^27.2.4",
+        "@jest/globals": "^27.2.4",
         "@jest/source-map": "^27.0.6",
-        "@jest/test-result": "^27.1.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
@@ -8714,17 +8719,17 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-mock": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-mock": "^27.2.4",
         "jest-regex-util": "^27.0.6",
-        "jest-resolve": "^27.1.0",
-        "jest-snapshot": "^27.1.0",
-        "jest-util": "^27.1.0",
-        "jest-validate": "^27.1.0",
+        "jest-resolve": "^27.2.4",
+        "jest-snapshot": "^27.2.4",
+        "jest-util": "^27.2.4",
+        "jest-validate": "^27.2.4",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^16.0.3"
+        "yargs": "^16.2.0"
       }
     },
     "jest-serializer": {
@@ -8738,9 +8743,9 @@
       }
     },
     "jest-snapshot": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
-      "integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.2.4.tgz",
+      "integrity": "sha512-5DFxK31rYS8X8C6WXsFx8XxrxW3PGa6+9IrUcZdTLg1aEyXDGIeiBh4jbwvh655bg/9vTETbEj/njfZicHTZZw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
@@ -8749,33 +8754,33 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/transform": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.1.0",
+        "expect": "^27.2.4",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.1.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "jest-haste-map": "^27.1.0",
-        "jest-matcher-utils": "^27.1.0",
-        "jest-message-util": "^27.1.0",
-        "jest-resolve": "^27.1.0",
-        "jest-util": "^27.1.0",
+        "jest-haste-map": "^27.2.4",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
+        "jest-resolve": "^27.2.4",
+        "jest-util": "^27.2.4",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.1.0",
+        "pretty-format": "^27.2.4",
         "semver": "^7.3.2"
       }
     },
     "jest-util": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
-      "integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.2.4.tgz",
+      "integrity": "sha512-mW++4u+fSvAt3YBWm5IpbmRAceUqa2B++JlUZTiuEt2AmNYn0Yw5oay4cP17TGsMINRNPSGiJ2zNnX60g+VbFg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -8784,17 +8789,17 @@
       }
     },
     "jest-validate": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
-      "integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.2.4.tgz",
+      "integrity": "sha512-VMtbxbkd7LHnIH7PChdDtrluCFRJ4b1YV2YJzNwwsASMWftq/HgqiqjvptBOWyWOtevgO3f14wPxkPcLlVBRog==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
+        "@jest/types": "^27.2.4",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^27.0.6",
         "leven": "^3.1.0",
-        "pretty-format": "^27.1.0"
+        "pretty-format": "^27.2.4"
       },
       "dependencies": {
         "camelcase": {
@@ -8806,24 +8811,24 @@
       }
     },
     "jest-watcher": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
-      "integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.2.4.tgz",
+      "integrity": "sha512-LXC/0+dKxhK7cfF7reflRYlzDIaQE+fL4ynhKhzg8IMILNMuI4xcjXXfUJady7OR4/TZeMg7X8eHx8uan9vqaQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.1.0",
-        "@jest/types": "^27.1.0",
+        "@jest/test-result": "^27.2.4",
+        "@jest/types": "^27.2.4",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.1.0",
+        "jest-util": "^27.2.4",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-      "integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.4.tgz",
+      "integrity": "sha512-Zq9A2Pw59KkVjBBKD1i3iE2e22oSjXhUKKuAK1HGX8flGwkm6NMozyEYzKd41hXc64dbd/0eWFeEEuxqXyhM+g==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -8893,9 +8898,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
           "dev": true
         }
       }
@@ -9278,12 +9283,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
-      "dev": true
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -9414,9 +9413,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -9429,13 +9428,13 @@
       }
     },
     "pretty-format": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-      "integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.0",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -9726,9 +9725,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -9742,9 +9741,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -9933,9 +9932,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -10035,9 +10034,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "universalify": {
@@ -10062,9 +10061,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -10184,9 +10183,9 @@
       }
     },
     "ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Colin Hemphill <colin@colinhemphill.com>",
   "homepage": "https://github.com/colinhemphill/haversack",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -42,23 +42,23 @@
   },
   "devDependencies": {
     "@testing-library/react-hooks": "7.0.2",
-    "@types/jest": "27.0.1",
-    "@types/react": "17.0.19",
-    "@typescript-eslint/eslint-plugin": "4.30.0",
-    "@typescript-eslint/parser": "4.30.0",
+    "@types/jest": "27.0.2",
+    "@types/react": "17.0.24",
+    "@typescript-eslint/eslint-plugin": "4.32.0",
+    "@typescript-eslint/parser": "4.32.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "husky": "7.0.2",
-    "jest": "27.1.0",
-    "jest-localstorage-mock": "2.4.17",
+    "jest": "27.2.4",
+    "jest-localstorage-mock": "2.4.18",
     "lint-staged": "11.1.2",
     "mockdate": "3.0.5",
-    "prettier": "2.3.2",
+    "prettier": "2.4.1",
     "react-test-renderer": "17.0.2",
     "ts-jest": "27.0.5",
-    "typescript": "4.4.2"
+    "typescript": "4.4.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17"

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,7 @@ type StorageKey = string;
 
 type StoredData = string | number | unknown[] | Record<string, unknown>;
 
-type Version = number;
+type Version = number | string;
 
 interface StorageStructure<T> {
   data?: T;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,12 +17,17 @@ export const safeGetStorageValue = <T>(
     if (value) {
       const { data, version, ts } = JSON.parse(value);
       const timestamp = new Date(ts);
-      const versionNumber =
-        typeof version !== 'undefined' ? Number(version) : undefined;
+      const parsedVersion =
+        typeof version !== 'undefined'
+          ? isNaN(Number(version))
+            ? version
+            : Number(version)
+          : undefined;
+
       parsedValue = {
         data,
         ts: timestamp,
-        version: versionNumber,
+        version: parsedVersion,
       };
     }
     return parsedValue ? parsedValue : {};

--- a/tests/serverSide.test.tsx
+++ b/tests/serverSide.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useLocalStorage, useSessionStorage } from '../src/index';
+
+describe('useLocalStorage and useSessionStorage hook SSR behavior', () => {
+  const key = 'testKey';
+  const value = 'testValue';
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetAllMocks();
+  });
+
+  test('Should return the default value on SSR, setValue is a noop', () => {
+    const { result } = renderHook(() => useLocalStorage(key, value));
+
+    act(() => {
+      result.current.setValue(value);
+    });
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+    expect(result.current.value).toBe(value);
+  });
+
+  test('Should return the default value on SSR, setValue is a noop', () => {
+    const { result } = renderHook(() => useSessionStorage(key, value));
+
+    act(() => {
+      result.current.setValue(value);
+    });
+
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
+    expect(result.current.value).toBe(value);
+  });
+});

--- a/tests/useLocalStorage.test.tsx
+++ b/tests/useLocalStorage.test.tsx
@@ -87,4 +87,34 @@ describe('useLocalStorage hook', () => {
 
     expect(result.current.value).toEqual(expectedStoredState);
   });
+
+  test('Should invalidate a previous version number', () => {
+    const ts = new Date();
+    mockdate.set(ts);
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version: 1,
+    });
+    localStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useLocalStorage(key, '', 2));
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  test('Should invalidate a previous version string', () => {
+    const ts = new Date();
+    mockdate.set(ts);
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version: 'old',
+    });
+    localStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useLocalStorage(key, '', 'new'));
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
 });

--- a/tests/useLocalStorage.test.tsx
+++ b/tests/useLocalStorage.test.tsx
@@ -5,11 +5,10 @@ import { useLocalStorage } from '../src/index';
 describe('useLocalStorage hook', () => {
   const key = 'testKey';
   const value = 'testValue';
-  const version = 1;
 
   beforeEach(() => {
     localStorage.clear();
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -23,7 +22,7 @@ describe('useLocalStorage hook', () => {
   });
 
   test('Should set the value to localStorage', () => {
-    const { result } = renderHook(() => useLocalStorage(key, '', version));
+    const { result } = renderHook(() => useLocalStorage(key));
 
     const ts = new Date();
     mockdate.set(ts);
@@ -35,7 +34,6 @@ describe('useLocalStorage hook', () => {
     const expectedStoredData = JSON.stringify({
       data: value,
       ts,
-      version,
     });
 
     expect(localStorage.setItem).toHaveBeenCalledWith(key, expectedStoredData);
@@ -116,5 +114,35 @@ describe('useLocalStorage hook', () => {
     renderHook(() => useLocalStorage(key, '', 'new'));
 
     expect(localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  test('Should not invalidate data with the same version number', () => {
+    const version = 1;
+    const ts = new Date();
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version,
+    });
+    localStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useLocalStorage(key, '', version));
+
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('Should not invalidate data with the same version string', () => {
+    const version = 'abc';
+    const ts = new Date();
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version,
+    });
+    localStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useLocalStorage(key, '', version));
+
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
   });
 });

--- a/tests/useSessionStorage.test.tsx
+++ b/tests/useSessionStorage.test.tsx
@@ -88,4 +88,34 @@ describe('useSessionStorage hook', () => {
 
     expect(result.current.value).toEqual(expectedStoredState);
   });
+
+  test('Should invalidate a previous version number', () => {
+    const ts = new Date();
+    mockdate.set(ts);
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version: 1,
+    });
+    sessionStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useSessionStorage(key, '', 2));
+
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  test('Should invalidate a previous version string', () => {
+    const ts = new Date();
+    mockdate.set(ts);
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version: 'old',
+    });
+    sessionStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useSessionStorage(key, '', 'new'));
+
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(key);
+  });
 });

--- a/tests/useSessionStorage.test.tsx
+++ b/tests/useSessionStorage.test.tsx
@@ -8,7 +8,7 @@ describe('useSessionStorage hook', () => {
 
   beforeEach(() => {
     sessionStorage.clear();
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -91,7 +91,6 @@ describe('useSessionStorage hook', () => {
 
   test('Should invalidate a previous version number', () => {
     const ts = new Date();
-    mockdate.set(ts);
     const previousStoredData = JSON.stringify({
       data: 'oldStoredData',
       ts,
@@ -106,7 +105,6 @@ describe('useSessionStorage hook', () => {
 
   test('Should invalidate a previous version string', () => {
     const ts = new Date();
-    mockdate.set(ts);
     const previousStoredData = JSON.stringify({
       data: 'oldStoredData',
       ts,
@@ -117,5 +115,35 @@ describe('useSessionStorage hook', () => {
     renderHook(() => useSessionStorage(key, '', 'new'));
 
     expect(sessionStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  test('Should not invalidate data with the same version number', () => {
+    const version = 1;
+    const ts = new Date();
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version,
+    });
+    sessionStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useSessionStorage(key, '', version));
+
+    expect(sessionStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('Should not invalidate data with the same version string', () => {
+    const version = 'abc';
+    const ts = new Date();
+    const previousStoredData = JSON.stringify({
+      data: 'oldStoredData',
+      ts,
+      version,
+    });
+    sessionStorage.setItem(key, previousStoredData);
+
+    renderHook(() => useSessionStorage(key, '', version));
+
+    expect(sessionStorage.removeItem).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## [1.2.1] - 2021-09-29

### Added

- New tests for SSR behavior
- New tests for versioning
- The `version` can now be a string in addition to a number
  - This is especially useful if you want to hash a data set to invalidate the cache dynamically

### Changed

- Dependency updates